### PR TITLE
Emit more diagnostics regarding what gcc uses implicitly

### DIFF
--- a/ci-set-env
+++ b/ci-set-env
@@ -43,6 +43,16 @@ if [ -z "$compiler" ]; then
  compiler=gcc
 fi
 $compiler --version || true
+
+case "$compiler" in
+*gcc)
+echo === implicit options/values with gcc ===
+ { $compiler -Q --help=common || true; } | grep -e '-[Wf]'
+;;
+*)
+;;
+esac
+
 ld --version || true
 export CC=$compiler
 


### PR DESCRIPTION
This is primarily to highlight whether -fcommon is enabled
(default prior to GCC 10) or disabled (changed at that very point).