### PR TITLE
Update for Pacemaker lifecycle changes

### DIFF
--- a/ci-build-src
+++ b/ci-build-src
@@ -29,10 +29,6 @@ case $build in
  ;;
  *)
   case "$DEST" in
-   pcmk1)
-    echo "$MAKE $MAKEOPTS"
-    $MAKE $MAKEOPTS || removerpmdeps 1
-   ;;
    pcs)
    ;;
    *)

--- a/ci-set-env
+++ b/ci-set-env
@@ -111,7 +111,7 @@ if [ "$build" != "rpm" ]; then
  BOOTH_INSTALL_PATH=/srv/booth/origin/master-pcmk-${pcmkver}/
 
  case $DEST in
-  pcmk1|corosync-flatiron|corosync-needle)
+  corosync-flatiron|corosync-needle)
    # old branches should only use system provided rpm to build
    KNET_INSTALL_PATH=""
    QB_INSTALL_PATH=""
@@ -280,7 +280,7 @@ else
  fi
 
  case $DEST in
-  pcmk1|corosync-flatiron|corosync-needle)
+  corosync-flatiron|corosync-needle)
    # old branches should only use system provided rpm to build
    KNET_REPO=""
    KNET_REPO_PATH=""

--- a/ci-set-env
+++ b/ci-set-env
@@ -86,7 +86,7 @@ if [ "$build" != "rpm" ]; then
  QB_INSTALL_PATH=/srv/qb/origin/master/
 
  # Latest Pacemaker release branch
- PCMK_RELEASE=2.0
+ PCMK_RELEASE=2.1
 
  # origin/master should use all master branches built
  # from sources

--- a/ci-set-env
+++ b/ci-set-env
@@ -85,6 +85,9 @@ if [ "$build" != "rpm" ]; then
  # exceptions below
  QB_INSTALL_PATH=/srv/qb/origin/master/
 
+ # Latest Pacemaker release branch
+ PCMK_RELEASE=2.0
+
  # origin/master should use all master branches built
  # from sources
  if [ "$TARGET" = "origin/master" ]; then
@@ -97,7 +100,7 @@ if [ "$build" != "rpm" ]; then
   KNET_INSTALL_PATH=/srv/knet/origin/stable1-proposed/
   COROSYNC_INSTALL_PATH=/srv/corosync/origin/camelback/
   if [ -z "${pcmkver}" ]; then
-   export pcmkver=2.0
+   export pcmkver="${PCMK_RELEASE}"
   fi
  fi
 
@@ -132,9 +135,8 @@ if [ "$build" != "rpm" ]; then
    ;;
   sbd|booth|pcs)
    # booth and sbd only have a master branch, but they need
-   # different settings when building against pcmk master or 2.0
-   if [ -n "${pcmkver}" ] && [ "${pcmkver}" = "2.0" ]; then
-    PCMK_INSTALL_PATH=/srv/pcmk/origin/2.0/
+   # different settings when building against pcmk master or release
+   if [ "${pcmkver}" = "${PCMK_RELEASE}" ]; then
     KNET_INSTALL_PATH=/srv/knet/origin/stable1-proposed/
     COROSYNC_INSTALL_PATH=/srv/corosync/origin/camelback/
    fi
@@ -275,8 +277,8 @@ else
   KNET_REPO_PATH=https://kronosnet.org/builds/knet/${NODE_NAME}/stable1-proposed/latest/
   COROSYNC_REPO=https://kronosnet.org/builds/corosync-camelback-${NODE_NAME}.repo
   COROSYNC_REPO_PATH=https://kronosnet.org/builds/corosync/${NODE_NAME}/camelback/latest/
-  PCMK_REPO=https://kronosnet.org/builds/pacemaker-2.0-${NODE_NAME}.repo
-  PCMK_REPO_PATH=https://kronosnet.org/builds/pacemaker/${NODE_NAME}/2.0/latest/
+  PCMK_REPO="https://kronosnet.org/builds/pacemaker-${PCMK_RELEASE}-${NODE_NAME}.repo"
+  PCMK_REPO_PATH="https://kronosnet.org/builds/pacemaker/${NODE_NAME}/${PCMK_RELEASE}/latest/"
  fi
 
  case $DEST in
@@ -311,14 +313,14 @@ else
    ;;
   sbd|booth|pcs)
    # booth and sbd only have a master branch, but they need
-   # different settings when building against pcmk master or 2.0
-   if [ -n "${pcmkver}" ] && [ "${pcmkver}" = "2.0" ]; then
+   # different settings when building against pcmk master or release
+   if [ "${pcmkver}" = "${PCMK_RELEASE}" ]; then
     KNET_REPO=https://kronosnet.org/builds/knet-stable1-proposed-${NODE_NAME}.repo
     KNET_REPO_PATH=https://kronosnet.org/builds/knet/${NODE_NAME}/stable1-proposed/latest/
     COROSYNC_REPO=https://kronosnet.org/builds/corosync-camelback-${NODE_NAME}.repo
     COROSYNC_REPO_PATH=https://kronosnet.org/builds/corosync/${NODE_NAME}/camelback/latest/
-    PCMK_REPO=https://kronosnet.org/builds/pacemaker-2.0-${NODE_NAME}.repo
-    PCMK_REPO_PATH=https://kronosnet.org/builds/pacemaker/${NODE_NAME}/2.0/latest/
+    PCMK_REPO=https://kronosnet.org/builds/pacemaker-${PCMK_RELEASE}-${NODE_NAME}.repo
+    PCMK_REPO_PATH=https://kronosnet.org/builds/pacemaker/${NODE_NAME}/${PCMK_RELEASE}/latest/
    fi
    ;;
  esac

--- a/ci-setup-rpm
+++ b/ci-setup-rpm
@@ -4,7 +4,7 @@ set -ev
 
 . $HOME/ci-tools/ci-rpm-common
 
-if [ "$build" = rpm ] || [ "$DEST" = pcmk1 ]; then
+if [ "$build" = "rpm" ]; then
  if [ -n "$RPMDEPS" ]; then
   echo "Installing rpm deps: $RPMDEPS"
   installrpmdeps

--- a/ci-setup-src
+++ b/ci-setup-src
@@ -15,7 +15,7 @@ fi
 
 if [ -f ./configure ]; then
  # workaround bug in pacemaker test suite
- if [ "$DEST" = "pcmk" ] || [ "$DEST" = "pcmk1" ]; then
+ if [ "$DEST" = "pcmk" ]; then
   echo "./configure $DISTROCONFOPTS PKG_CONFIG_PATH=$EXTERNAL_CONFIG_PATH"
   ./configure $DISTROCONFOPTS PKG_CONFIG_PATH=$EXTERNAL_CONFIG_PATH
  else

--- a/ci-tests-src
+++ b/ci-tests-src
@@ -33,10 +33,6 @@ pcmkextratests() {
  if [ "$DEST" = pcmk ]; then
   ./cts/cts-regression -V
  fi
- if [ "$DEST" = pcmk1 ]; then
-  ./BasicSanity.sh -V || removerpmdeps 1
-  removerpmdeps 0
- fi
 }
 
 case $build in


### PR DESCRIPTION
Pacemaker's 1.1 and 2.0 branches will no longer get PRs and do not need to be tested, and its new 2.1 branch needs to be added.