### PR TITLE
kernel-ark: enable KASAN and UBSAN

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
 			sh '''
 			    cd $BUILDDIR/kernel-ark
 			    echo == build srpm ==
-			    make -j $(nproc) dist-srpm
+			    make -j $(nproc) CONFIG_KASAN=y CONFIG_UBSAN=y dist-srpm
 			'''
 		    }
 		}


### PR DESCRIPTION
This patch enables KASAN and UBSAN runtime santizer checks. This can be useful to found some misbehaviours when kronosnet-ci runs testing for GFS2 and DLM.

There are multiple ways how to activate a kernel config. This is the simplest way if there is no .config file.