### PR TITLE
kernel-ark: set kernelconfigs via kernel-ark-config repo

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -91,6 +91,8 @@ pipeline {
 				git remote add gfs2 git://git.kernel.org/pub/scm/linux/kernel/git/gfs2/linux-gfs2.git
 				echo "Adding remote linux-dlm.git"
 				git remote add dlm git://git.kernel.org/pub/scm/linux/kernel/git/teigland/linux-dlm.git
+				echo "Adding remote kernel-ark.git for config"
+				git remote add kernel-ark-config https://gitlab.com/netcoder/kernel-ark.git
 			    fi
 			'''
 		    }
@@ -107,6 +109,8 @@ pipeline {
 			    git fetch gfs2
 			    echo == fetch dlm ==
 			    git fetch dlm
+			    echo == fetch kernel-ark-config ==
+			    git fetch kernel-ark-config
 			    echo == reset tree to origin/$ARK_BRANCH ==
 			    git reset --hard origin/$ARK_BRANCH
 			'''
@@ -121,14 +125,14 @@ pipeline {
 			'''
 		    }
 		}
-		stage('Merging kernel-ark / gfs2 / dlm trees') {
+		stage('Merging kernel-ark / gfs2 / dlm / kernel-ark-config trees') {
 		    steps {
 			sh '''
 			    cd $BUILDDIR/kernel-ark
 			    echo == checkout ci-test branch ==
 			    git checkout -b ci-test
-			    echo == merge gfs2/for-next and dlm/next ==
-			    git merge --log=999 --no-ff -m 'Automatic merge of gfs2/for-next and dlm/next' gfs2/for-next dlm/next
+			    echo == merge gfs2/for-next dlm/next and kernel-ark-config/ci_test_config ==
+			    git merge --log=999 --no-ff -m 'Automatic merge of gfs2/for-next dlm/next and kernel-ark-config/ci_test_config' gfs2/for-next dlm/next kernel-ark-config/ci_test_config
 			    git show --no-patch
 			    echo == apply workaround for debuginfo package build ==
 			    git revert --no-edit 7dc0430e5e007a7441a8f5109276df99b4cf48a7
@@ -149,7 +153,7 @@ pipeline {
 			sh '''
 			    cd $BUILDDIR/kernel-ark
 			    echo == build srpm ==
-			    make -j $(nproc) CONFIG_KASAN=y CONFIG_UBSAN=y dist-srpm
+			    make -j $(nproc) dist-srpm
 			'''
 		    }
 		}


### PR DESCRIPTION
This patch drops the current way of setting kernel configfs for kernel-ark project. It is confirmed by checking the rpm kernelconfig file that those configs are not activated.

The hopefully right way is to follow instruction [0] that describes to put additional kernelconfigs into custom-overrides/generic or custom-overrides/debug. Those directories are always empty and made for possible user changes and should be "mergable" without any conflicts to activate additional configs that will be considered by the build_configs.sh script.

Also we activate DEBUG_ATOMIC_SLEEP to notify over the kernel log if there are any cases when we sleep while atomic context.

In combination with the sosreports it is easy to find any KASAN, UBSAN or atomic sleep issues.

[0] https://gitlab.com/cki-project/kernel-ark/-/tree/os-build/redhat/configs