### PR TITLE
Kernel ark fixes

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -117,6 +117,8 @@ pipeline {
 			    done
 			    echo == reset tree to origin/os-build ==
 			    git reset --hard origin/os-build
+			    echo == clean tree ==
+			    git clean -dfx
 			"""
 		    }
 		}

--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -135,10 +135,14 @@ pipeline {
 		    steps {
 			sh '''
 			    cd $BUILDDIR/kernel-ark
-			    echo == checkout ci-test branch ==
+			    echo == checkout kernel-ark-config/ci_test_config ==
+			    git checkout kernel-ark-config/ci_test_config
+			    echo == checkout -b ci-test branch ==
 			    git checkout -b ci-test
-			    echo == merge gfs2/for-next dlm/next and kernel-ark-config/ci_test_config ==
-			    git merge --log=999 --no-ff -m 'Automatic merge of gfs2/for-next dlm/next and kernel-ark-config/ci_test_config' gfs2/for-next dlm/next kernel-ark-config/ci_test_config
+			    echo == rebase to origin/$ARK_BRANCH ==
+			    git rebase origin/$ARK_BRANCH
+			    echo == merge gfs2/for-next and dlm/next ==
+			    git merge --log=999 --no-ff -m 'Automatic merge of gfs2/for-next and dlm/next' gfs2/for-next dlm/next
 			    git show --no-patch
 			    echo == apply workaround for debuginfo package build ==
 			    git revert --no-edit 7dc0430e5e007a7441a8f5109276df99b4cf48a7


### PR DESCRIPTION
Some kernel-ark ci fixes. Run git clean -dfx and rebase the kernel-ark config fork and don't merge it.