### PR TITLE
kernel-ark: replace ARK_BRANCH var with value

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -139,8 +139,8 @@ pipeline {
 			    git checkout kernel-ark-config/ci_test_config
 			    echo == checkout -b ci-test branch ==
 			    git checkout -b ci-test
-			    echo == rebase to origin/$ARK_BRANCH ==
-			    git rebase origin/$ARK_BRANCH
+			    echo == rebase to origin/os-build ==
+			    git rebase origin/os-build
 			    echo == merge gfs2/for-next and dlm/next ==
 			    git merge --log=999 --no-ff -m 'Automatic merge of gfs2/for-next and dlm/next' gfs2/for-next dlm/next
 			    git show --no-patch


### PR DESCRIPTION
There was a rebase issue, in older version of the Jenkinsfile there was a ARK_BRANCH value which does not exists upstream anymore. This patch will replace it with os-build as it done in commit 85381d4 ("kernel-ark: simplify pipeline and prep for custom repos").

Sorry!