### PR TITLE
There is at most one package repository

### DIFF
--- a/pipelines/libs/global/vars/getBuildInfoCommon.groovy
+++ b/pipelines/libs/global/vars/getBuildInfoCommon.groovy
@@ -13,7 +13,7 @@ def call(Map info)
     info['email_extra_text'] = ''
     info['covtgtdir'] = ''
     info['cov_results_urls'] = []
-    info['rpmlist'] = []
+    info['repo_url'] = ''
     info['new_cov_results_urls'] = []
     info['EXTRAVER_LIST'] = []
 

--- a/pipelines/libs/global/vars/runStage.groovy
+++ b/pipelines/libs/global/vars/runStage.groovy
@@ -149,12 +149,12 @@ def doRunStage(String agentName, Map info, Map localinfo)
 			cmdWithTimeout(collect_timeout,
 				       "$HOME/ci-tools/ci-wrap ci-get-artifacts ${agentName} ${workspace} builds/${info['project']}/pr/${info['pull_id']}/${agentName} rpm",
 				       stagestate, {}, { postFnError(stagestate) })
-			info['rpmlist'] += "https://ci.kronosnet.org/" + "builds/${info['project']}/pr/${info['pull_id']}/${agentName}"
+			info['repo_url'] = "https://ci.kronosnet.org/" + "builds/${info['project']}/pr/${info['pull_id']}/${agentName}"
 		    } else {
 			cmdWithTimeout(collect_timeout,
 				       "$HOME/ci-tools/ci-wrap ci-get-artifacts ${agentName} ${workspace} builds/${info['project']}/${agentName}/origin/${info['target']}/${localinfo['extraver']}/${env.BUILD_NUMBER}/ rpm",
 				       stagestate, {}, { postFnError(stagestate) })
-			info['rpmlist'] += "https://ci.kronosnet.org/" + "builds/${info['project']}/${agentName}/origin/${info['target']}/${localinfo['extraver']}/${env.BUILD_NUMBER}/"
+			info['repo_url'] = "https://ci.kronosnet.org/" + "builds/${info['project']}/${agentName}/origin/${info['target']}/${localinfo['extraver']}/${env.BUILD_NUMBER}/"
 
 		    }
 		}

--- a/pipelines/libs/global/vars/sendEmails.groovy
+++ b/pipelines/libs/global/vars/sendEmails.groovy
@@ -148,19 +148,15 @@ def call(Map info)
 	runreason = "Run reason: ${currentBuild.getBuildCauses().shortDescription[0]}"
     }
 
-    def rpm_urls = ''
-    if (info.containsKey('rpmlist') && info['rpmlist'].size() > 0) {
-	rpm_urls = "RPMS:\n"
-	for (r in info['rpmlist']) {
-	    rpm_urls += "${r}\n"
-	}
-	rpm_urls += "\n"
+    def repo_url = ''
+    if (info['repo_url'] != '') {
+	repo_url = "Repository: ${info['repo_url']}\n"
     }
     def email_trailer = """${runreason}
 Total runtime: ${jobDuration}
 ${split_logs}
 Full log:   ${console_log}
-${rpm_urls}${cov_urls}
+${repo_url}${cov_urls}
 ${info['email_extra_text']}
 ${info['exception_text']}
 """

--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -197,7 +197,7 @@ pipeline {
 			    timeout (time: 15, unit: 'MINUTES') {
 				sh "$HOME/ci-tools/ci-wrap ci-get-artifacts ${BUILDNODE} ${BUILDDIR}/rpms builds/kernel/rhel9-kbuild/origin/${BRANCH_NAME}/${BUILD_NUMBER}/ rpm"
 				script {
-				    info['rpmlist'] = ["https://ci.kronosnet.org/" + "builds/kernel/rhel9-kbuild/origin/${BRANCH_NAME}/${BUILD_NUMBER}"]
+				    info['repo_url'] = "https://ci.kronosnet.org/" + "builds/kernel/rhel9-kbuild/origin/${BRANCH_NAME}/${BUILD_NUMBER}"
 				}
 			    }
 			}


### PR DESCRIPTION
At most one repository of RPM packages will be created per build, so there is no need to keep a list of repositories.  (We are not keeping a list of RPMs, either.)

This also makes the notification emails look less weird.