### PR TITLE
kernel-ark: attempt to force clean redhat/ after rsync

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -129,6 +129,8 @@ pipeline {
 			    echo == clone tree to build dir ==
 			    cd $BUILDDIR
 			    rsync -a $CACHEDIR/kernel-ark .
+			    echo == clean redhat/ again ==
+			    git clean -dfx redhat/
 			'''
 		    }
 		}


### PR DESCRIPTION
Just a shot in the dark to try to fix issues what we currently have with the redhat .config generator and ensure redhat/ directory is clean (as no generated files are there) after the rsync.

I have no other idea why we currently have those problems.