### PR TITLE
use downstream packages

### DIFF
--- a/ci-setup-src
+++ b/ci-setup-src
@@ -20,26 +20,24 @@ if [ -f ./configure ]; then
    echo "Random sleep: $sleeptimer"
    sleep $sleeptimer
 
+   rm -rf .venv
+   python3 -m venv --system-site-packages .venv
+   . .venv/bin/activate
+   export PATH="$(pwd)/.venv"/bin/:$PATH
+
    case "${NODE_NAME}" in
     debian*|ubuntu*)
      localbuild=""
-     usesitepackages=--system-site-packages
      ;;
     rhel-8*)
+     python3 -m pip install concurrencytest
      localbuild=--enable-local-build
-     usesitepackages=--system-site-packages
      ;;
     *)
      localbuild=--enable-local-build
-     usesitepackages=""
      ;;
    esac
-   rm -rf .venv
-   python3 -m venv $usesitepackages .venv
-   . .venv/bin/activate
-   export PATH="$(pwd)/.venv"/bin/:$PATH
-   python3 -m pip install setuptools-scm setuptools-rust wheel
-   python3 -m pip install concurrencytest cryptography lxml pycurl six pyparsing
+
    echo "./configure --enable-destructive-tests --enable-parallel-tests $localbuild $DISTROCONFOPTS PKG_CONFIG_PATH=$EXTERNAL_CONFIG_PATH"
    ./configure --enable-destructive-tests --enable-parallel-tests $localbuild $DISTROCONFOPTS PKG_CONFIG_PATH=$EXTERNAL_CONFIG_PATH
    ;;

--- a/ci-update-apt
+++ b/ci-update-apt
@@ -74,6 +74,8 @@ required_pkg pkg-config
 required_pkg psmisc
 required_pkg puma
 required_pkg python3-boto3
+required_pkg python3-dateutil
+required_pkg python3-cryptography
 required_pkg python3-dev
 required_pkg python3-googleapi
 required_pkg python3-lxml
@@ -90,6 +92,7 @@ required_pkg python3-suds
 required_pkg python3-systemd
 required_pkg python3-tornado
 required_pkg python3-venv
+required_pkg python3-wheel
 required_pkg rsync
 required_pkg ruby
 required_pkg ruby-backports

--- a/ci-update-yum
+++ b/ci-update-yum
@@ -156,6 +156,7 @@ required_pkg overpass-fonts
 required_pkg pam-devel
 required_pkg perl
 required_pkg python3-cryptography
+required_pkg python3-dateutil
 required_pkg python3-devel
 required_pkg python3-httplib2
 required_pkg python3-lxml
@@ -163,6 +164,7 @@ required_pkg python3-pexpect
 required_pkg python3-pip
 required_pkg python3-psutil
 required_pkg python3-pycurl
+required_pkg python3-pyparsing
 required_pkg python3-pyroute2
 required_pkg python3-requests
 required_pkg python3-rpm-macros


### PR DESCRIPTION
@chrissie-c, please, test this in cc-devel. I have the https://github.com/ClusterLabs/pcs/pull/864 open for testing, but let me first push a commit to disable the tests that are failing due to pacemaker before testing this, I'll let you know.
 
Cryptography is currently broken upstream due to deprecation of OpenSSL engines in Fedora 41+ and CentOS Stream 10. I managed to merge a fix upstream, but that will take some time until they release a new version. For more details, see the GitHub issue:
https://github.com/pyca/cryptography/issues/11690