### PR TITLE
kernel-ark: disable more user space tooling and docs

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
 			    cd $BUILDDIR/kernel-ark
 			    echo == build rpms ==
 			    srcrpm=$(ls -1 redhat/rpm/SRPMS/kernel-*.src.rpm)
-			    RPMBUILDOPTS="--without debug --without doc --without realtime --without automotive --without ynl --without selftests"
+			    RPMBUILDOPTS="--without debug --without doc --without realtime --without automotive --without ynl --without selftests --without_perf --without_libperf --without_tools"
 
 			    CIRPMDIR=$(pwd)/ci-test-rpms
 			    rm -rf $CIRPMDIR


### PR DESCRIPTION
disable more user space tooling that we don't need to avoid potential compile issues with them that are currently around.