### PR TITLE
kernel-ark: fix underscore to blank

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
 			    cd $BUILDDIR/kernel-ark
 			    echo == build rpms ==
 			    srcrpm=$(ls -1 redhat/rpm/SRPMS/kernel-*.src.rpm)
-			    RPMBUILDOPTS="--without debug --without doc --without realtime --without automotive --without ynl --without selftests --without_perf --without_libperf --without_tools"
+			    RPMBUILDOPTS="--without debug --without doc --without realtime --without automotive --without ynl --without selftests --without perf --without libperf --without tools"
 
 			    CIRPMDIR=$(pwd)/ci-test-rpms
 			    rm -rf $CIRPMDIR


### PR DESCRIPTION
sorry, just copied out of the spec template and forget to replace the underscore with blanks.