### PR TITLE
Pacemaker: Disable INCONSISTENT_UNION_ACCESS checker

### DIFF
--- a/pipelines/projects/pacemaker/vars/getCovOpts.groovy
+++ b/pipelines/projects/pacemaker/vars/getCovOpts.groovy
@@ -2,5 +2,10 @@
 def call(String branch)
 {
     // We can make decisions based on the branch if needed
-    return '--all --disable STACK_USE --disable-parse-warnings'
+
+    /* @COMPAT Prior to GLib 2.58, the implementation of g_clear_pointer()
+     * triggers the INCONSISTENT_UNION_ACCESS warning. Re-enable that warning
+     * when Pacemaker requires GLib >= 2.58.
+     */
+    return '--all --disable STACK_USE --disable-parse-warnings --disable INCONSISTENT_UNION_ACCESS'
 }


### PR DESCRIPTION
The new Coverity is throwing an `INCONSISTENT_UNION_ACCESS` error.

The error comes from GLib's `g_clear_pointer()` macro. (It seems to be fixed in GLib version 2.58, but we're bound to the version 2.42 API for now.)

We cannot annotate the macro directly with a suppression, since it lives in GLib's headers. (A hacky workaround might be possible, by wrapping the macro or redefining it or something.)

We rarely use unions within Pacemaker, so I'm okay with disabling the `INCONSISTENT_UNION_ACCESS` check globally.

Edit: adding a custom model to override Coverity's view of `g_clear_pointer()` would likely be possible, but it would be more invasive.
* https://documentation.blackduck.com/bundle/coverity-docs/page/customizing_coverity/topics/models_primitives/c_models_examples_c_cpp.html#ariaid-title4