### PR TITLE
kernel-ark: switch from os-build to ark-latest

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -122,8 +122,8 @@ pipeline {
 				echo == fetch \$remote ==
 				git fetch \$remote
 			    done
-			    echo == reset tree to origin/os-build ==
-			    git reset --hard origin/os-build
+			    echo == reset tree to origin/ark-latest ==
+			    git reset --hard origin/ark-latest
 			    echo == clean tree ==
 			    git clean -dfx
 			"""


### PR DESCRIPTION
According to the kernel team it is more stable for testing.