### PR TITLE
kernel-ark: switch from merge to cherry-pick

### DIFF
--- a/pipelines/projects/kernel-ark/Jenkinsfile
+++ b/pipelines/projects/kernel-ark/Jenkinsfile
@@ -142,12 +142,20 @@ pipeline {
 		    steps {
 			sh '''
 			    cd $BUILDDIR/kernel-ark
-			    for branch in gfs2/for-next dlm/next kernel-ark-config/ci_test_config; do
+			    for branch in gfs2/for-next dlm/next; do
 				if ! git merge-base --is-ancestor "$branch" HEAD; then
 				    git merge --log=999 --no-ff -m "Automatic merge of $branch" $branch
 				    git show --no-patch
 				fi
 			    done
+			'''
+		    }
+		}
+		stage('Cherry-pick config changes') {
+		    steps {
+			sh '''
+			    cd $BUILDDIR/kernel-ark
+			    git cherry-pick 4195c83be5416..kernel-ark-config/ci_test_config
 			'''
 		    }
 		}


### PR DESCRIPTION
The history of kernel-ark/ark-latest get forced pushs, the based tree that change configuration changes for kernel-ark/ark-latest configuration generator will complain about if we doing a merge because the history does not match anymore.

Instead of doing a merge we switch to apply the patches by using cherry-pick which should work more often as the related areas are touched rarely.